### PR TITLE
docs: align intro taglines to highlight agentic workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Genkit Python SDK
 
-Build production-ready AI applications and agentic workflows in Python with type-safe flows, structured outputs, and integrated observability.
+Genkit is Google's open-source framework for building full-stack, AI-powered and agentic applications. Build production-ready Python AI features with type-safe flows, structured outputs, and integrated observability.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Genkit Python SDK
 
-Build production-ready AI applications in Python with type-safe flows, structured outputs, and integrated observability.
+Build production-ready AI applications and agentic workflows in Python with type-safe flows, structured outputs, and integrated observability.
 
 ## Quick Start
 

--- a/packages/genkit/README.md
+++ b/packages/genkit/README.md
@@ -1,6 +1,6 @@
 # genkit
 
-Genkit is a framework designed to help you build AI-powered applications and features.
+Genkit is an open-source framework designed to help you build AI-powered applications and agentic workflows.
 It provides open source libraries for Python, Node.js and Go, plus developer tools for testing
 and debugging.
 

--- a/packages/genkit/README.md
+++ b/packages/genkit/README.md
@@ -1,7 +1,7 @@
 # genkit
 
-Genkit is an open-source framework designed to help you build AI-powered applications and agentic workflows.
-It provides open source libraries for Python, Node.js and Go, plus developer tools for testing
+Genkit is Google's open-source framework for building full-stack, AI-powered and agentic applications.
+It provides open-source libraries for Python, Node.js, and Go, plus developer tools for testing
 and debugging.
 
 You can deploy and run Genkit libraries anywhere Python is supported. It's designed to work with


### PR DESCRIPTION
## Description
Updates the intro taglines in `README.md` and `packages/genkit/README.md` to align with the genkit.dev messaging and highlight building **AI-powered applications and agentic workflows**.

This addresses feedback from @ashaban to explicitly mention agentic apps/workflows in the Python repository intro.

## Changes
- **`README.md`**: "Build production-ready AI applications and agentic workflows in Python..."
- **`packages/genkit/README.md`**: "Genkit is an open-source framework designed to help you build AI-powered applications and agentic workflows."